### PR TITLE
Store preference for users who Accept All

### DIFF
--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/package-lock.json
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/package-lock.json
@@ -10064,6 +10064,12 @@
       "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==",
       "dev": true
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/package.json
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "start": "NODE_ENV=develop webpack-dev-server --config ./webpack.config.js --mode development",
     "build": "webpack --mode production",
-    "lint": "stylelint --fix \"**/*.scss\" && standardx --fix **/*.ts",
+    "lint": "stylelint \"**/*.scss\" && standardx **/*.ts",
+    "fixlint": "stylelint --fix \"**/*.scss\" && standardx --fix **/*.ts",
     "test": "jest --collectCoverage",
     "analyze": "webpack --mode production --profile --json > stats.json && webpack-bundle-analyzer stats.json"
   },

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/package.json
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/package.json
@@ -54,6 +54,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^25.1.0",
     "jest-environment-jsdom-fourteen": "^1.0.1",
+    "js-cookie": "^2.2.1",
     "node-sass": "^4.13.1",
     "sass-loader": "^8.0.2",
     "standardx": "^5.0.0",
@@ -64,9 +65,9 @@
     "ts-jest": "^25.2.1",
     "ts-loader": "^6.2.1",
     "typescript": "^3.8.3",
+    "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^4.42.0",
     "webpack-bundle-analyzer": "^3.6.0",
-    "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3"
   }

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/index.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/index.ts
@@ -1,8 +1,9 @@
 import '../styles/styles.scss'
 import renderBanner from './ui/renderBanner'
+import userPreferenceFactory from './userPreferenceFactory'
 import enableGtm from './enableGtm'
 
 enableGtm()
 document.addEventListener('DOMContentLoaded', () => {
-  renderBanner()
+  renderBanner(userPreferenceFactory())
 })

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/ui/renderBanner.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/ui/renderBanner.ts
@@ -1,10 +1,16 @@
 // @ts-ignore
 import bannerHtml from './banner.html';
 
-const renderBanner = () => {
+const renderBanner = (userPreference) => {
     const banner = document.createElement('div')
     banner.className = banner.className + ' cookie-banner';
     banner.innerHTML = bannerHtml
+    banner.querySelectorAll('.acceptAll').forEach(acceptAllButton => {
+        (acceptAllButton).addEventListener('click', e => {
+            e.preventDefault()
+            userPreference.userAcceptsAll()
+        })
+    })
     const parentNode = document.body
     parentNode.insertBefore(banner, parentNode.firstChild)
 }

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/userPreferenceFactory.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/userPreferenceFactory.ts
@@ -1,0 +1,16 @@
+// @ts-ignore
+import Cookies from 'js-cookie'
+
+const userPreferenceFactory = () => ({
+  userAcceptsAll: () => {
+    Cookies.set('userConsent', JSON.stringify({
+      version: '2020-01-01',
+      dateSet: new Date().getTime(),
+      preferences: {
+        acceptAll: true
+      }
+    }), { secure: true, sameSite: 'strict' })
+  }
+})
+
+export default userPreferenceFactory

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/userPreferenceFactory.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/userPreferenceFactory.ts
@@ -9,7 +9,7 @@ const userPreferenceFactory = () => ({
       preferences: {
         acceptAll: true
       }
-    }), { secure: true, sameSite: 'strict' })
+    }), { sameSite: 'strict', expires: 3650 })
   }
 })
 

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/renderBanner.spec.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/renderBanner.spec.ts
@@ -1,13 +1,46 @@
+/* global spyOn */
+
 import {
   queryByText
 } from '@testing-library/dom'
 import '@testing-library/jest-dom/extend-expect'
+import userPreferenceFactory from '../src/userPreferenceFactory'
 import renderBanner from '../src/ui/renderBanner'
 
 describe('index', () => {
+  const reset = () => {
+    document.getElementsByTagName('html')[0].innerHTML = ''
+  }
+  const click = (elem) => {
+    const event = document.createEvent('HTMLEvents')
+    event.initEvent('click', false, true)
+    elem.dispatchEvent(event)
+  }
+  const assume = expect
+
+  beforeAll(reset)
+  afterEach(reset)
+
   it('should render a banner', () => {
-    renderBanner()
+    renderBanner(userPreferenceFactory())
 
     expect(queryByText(document.body, /Tell us whether you accept cookies/)).toBeTruthy()
+  })
+
+  it('should call preference manager when user accepts', () => {
+    const userPreference = userPreferenceFactory()
+    spyOn(userPreference, 'userAcceptsAll')
+    renderBanner(userPreference)
+    const acceptAllButton = document.querySelector('.cookie-banner .acceptAll')
+    assume(userPreference.userAcceptsAll).not.toHaveBeenCalled()
+
+    click(acceptAllButton)
+    expect(userPreference.userAcceptsAll).toHaveBeenCalledWith()
+  })
+
+  describe('Meta tests', () => {
+    it('should reset state between tests', () => {
+      expect(queryByText(document.body, /Tell us whether you accept cookies/)).toBeFalsy()
+    })
   })
 })

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/userPreference.spec.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/userPreference.spec.ts
@@ -41,7 +41,7 @@ describe('User Preference Factory', () => {
 
   it('should set cookie security appropriately', () => {
     userPreferenceFactory().userAcceptsAll()
-    expect(Cookies.set).toHaveBeenCalledWith('userConsent', anything(), { sameSite: 'strict', secure: true })
+    expect(Cookies.set).toHaveBeenCalledWith('userConsent', anything(), { sameSite: 'strict', expires: 3650 })
   })
 
   describe('Meta tests', () => {

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/userPreference.spec.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/userPreference.spec.ts
@@ -1,0 +1,54 @@
+/* global jasmine, spyOn */
+import Cookies from 'js-cookie'
+import userPreferenceFactory from '../src/userPreferenceFactory'
+import anything = jasmine.anything;
+
+describe('User Preference Factory', () => {
+  let fakeDateTime = 1591234567890
+
+  beforeEach(() => {
+    spyOn(Cookies, 'set')
+    spyOn(Date.prototype, 'getTime').and.callFake(() => fakeDateTime)
+  })
+
+  const expectTrackingPreferenceToHaveBeenSetWith = (preference) => {
+    expect(Cookies.set).toHaveBeenCalledWith('userConsent', JSON.stringify(preference), anything())
+    expect(Cookies.set).toHaveBeenCalledTimes(1)
+  }
+
+  it('should set the cookie body with the JSON format', () => {
+    userPreferenceFactory().userAcceptsAll()
+    expectTrackingPreferenceToHaveBeenSetWith({
+      version: '2020-01-01',
+      dateSet: fakeDateTime,
+      preferences: {
+        acceptAll: true
+      }
+    })
+  })
+
+  it('should set the cookie body with the correct dateTime', () => {
+    fakeDateTime = 987654321
+    userPreferenceFactory().userAcceptsAll()
+    expectTrackingPreferenceToHaveBeenSetWith({
+      version: '2020-01-01',
+      dateSet: 987654321,
+      preferences: {
+        acceptAll: true
+      }
+    })
+  })
+
+  it('should set cookie security appropriately', () => {
+    userPreferenceFactory().userAcceptsAll()
+    expect(Cookies.set).toHaveBeenCalledWith('userConsent', anything(), { sameSite: 'strict', secure: true })
+  })
+
+  describe('Meta tests', () => {
+    it('datetime should be settable', () => {
+      expect(new Date().getTime()).toEqual(fakeDateTime)
+      fakeDateTime = 123
+      expect(new Date().getTime()).toEqual(123)
+    })
+  })
+})


### PR DESCRIPTION
This stores the preference but doesn't read it back.

I've used a self-contained cookie library as it makes the unit tests manageable.  I tried to use JSDOM's `CookieJar` but the integration point is difficult to track down and reset.

A few decisions which need reviewing:

- I'm not using secure (https only) cookies, these should be used in production but wouldn't be supported in local development.
- I've set the expiry for 10 years, I'm keen on storing the datetime that the user set the preferences so we can use that to invalidate them when we want to.  The approach I've chosen means we can choose to ask again for the user's preference after a year if we want/need to but we're not limited to doing that for technical reasons.  Some of our users will use the site annually.
- I put the event handler into the render function, I feel like that's not the best place for it.

A few changes I made alongside this:

- I added a reset to the render test, the previous version wasn't suitable for more than one test case.  This version is not future-proof, the reset only deals with elements added and not (things like) events on the body element which might cause problems later.
- I changed the lint task to *just* lint and not fix, to fix you'd need to run `npm run fixlint`.  I don't think we should be mutating code on a commit command.

The next step to hook this in is:

- To fire an event on the `datalayer` when we pick up the cookie which allows us to initialise tracking.  This should happen on each page load.