### PR TITLE
Fixed issues with querySelectorAll on IE10, refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,5 @@ coverage
 node_modules
 stats.json
 public/bundle.js
-public/cookieSettingsPage.js
+public/settingsPage.js
+

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/common/fromEntries.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/common/fromEntries.ts
@@ -1,5 +1,6 @@
-const fromEntries = <T>(entries: [string?, T?][]) => entries.reduce(
-    (accumulator: {}, [key, value]): {} => (key ? { ...accumulator, [key]: value } : { ...accumulator }), {}
+// Polyfill for Object.fromEntries https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries
+const fromEntries = <T>(entries: [string, T][]) => entries.reduce(
+    (accumulator: {}, [key, value]): {} => ({ ...accumulator, [key]: value }), {}
 )
 
 export default fromEntries

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/common/fromEntries.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/common/fromEntries.ts
@@ -1,0 +1,5 @@
+const fromEntries = <T>(entries: [string, T][]) => entries.reduce(
+    (accumulator: {}, [key, value]): {} => ({ ...accumulator, [key]: value }), {}
+)
+
+export default fromEntries

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/common/fromEntries.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/common/fromEntries.ts
@@ -1,5 +1,5 @@
-const fromEntries = <T>(entries: [string, T][]) => entries.reduce(
-    (accumulator: {}, [key, value]): {} => ({ ...accumulator, [key]: value }), {}
+const fromEntries = <T>(entries: [string?, T?][]) => entries.reduce(
+    (accumulator: {}, [key, value]): {} => (key ? { ...accumulator, [key]: value } : { ...accumulator }), {}
 )
 
 export default fromEntries

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/settingsFormHandler.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/settingsFormHandler.ts
@@ -36,18 +36,16 @@ const hydrateForm = (userPreferences: UserPreferences) => (form: HTMLFormElement
   }
 
   const mapFormToPreferences = () => {
-    const entries: [string?, boolean?][] = cookieTypes.map(cookieType => {
+    const entries: [string, boolean][] = cookieTypes.reduce((accumulator, cookieType) => {
       const onInput: HTMLInputElement | null = form.querySelector(`input[name=${cookieType}][value=${onValue}`)
       const offInput: HTMLInputElement | null = form.querySelector(`input[name=${cookieType}][value=${offValue}`)
-      if (onInput === null || offInput === null) {
-        return []
-      } else {
-        if (!onInput.checked && !offInput.checked) {
-          return []
-        }
-        return [cookieType, onInput.checked]
-      }
-    })
+
+      // If form inputs are missing or user has not specified consent either way, do not set a preference,
+      // Otherwise the preference is determined by checking whether the on input is checked
+      return onInput === null || offInput === null || (!onInput.checked && !offInput.checked)
+        ? accumulator
+        : [...accumulator, [cookieType, onInput.checked]]
+    }, [])
 
     return fromEntries(entries)
   }

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/settingsPage.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/settingsPage.ts
@@ -1,4 +1,6 @@
 import settingsFormHandler from './settingsFormHandler'
 import userPreferenceFactory from './userPreferenceFactory'
 
-settingsFormHandler(document, userPreferenceFactory())
+document.addEventListener('DOMContentLoaded', () => {
+  settingsFormHandler(document, userPreferenceFactory())
+})

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/settingsPage.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/settingsPage.ts
@@ -1,6 +1,4 @@
 import settingsFormHandler from './settingsFormHandler'
 import userPreferenceFactory from './userPreferenceFactory'
 
-document.addEventListener('DOMContentLoaded', () => {
-  settingsFormHandler(document, userPreferenceFactory())
-})
+settingsFormHandler(document, userPreferenceFactory())

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/userPreferenceFactory.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/userPreferenceFactory.ts
@@ -25,7 +25,7 @@ const userPreferenceFactory = () => ({
   getPreferences: () => {
     const rawCookie = Cookies.get('userConsent')
     if (rawCookie) {
-      const parsedCookie = rawCookie ? JSON.parse(rawCookie) : undefined
+      const parsedCookie = JSON.parse(rawCookie)
       const pref = parsedCookie.preferences
       if (pref.acceptAll) {
         return {

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/common/fromEntries.spec.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/common/fromEntries.spec.ts
@@ -1,0 +1,19 @@
+import fromEntries from "../../src/common/fromEntries";
+
+describe('fromEntries', () => {
+  it('should convert an array of key value pairs to an object', () => {
+    const entries: [string, number][] = [['a', 1], ['b', 2]]
+
+    const object = fromEntries(entries)
+
+    expect(object).toEqual({ a: 1, b: 2 })
+  })
+
+  it('should convert an empty array to an empty object', () => {
+    const entries: [string, number][] = []
+
+    const object = fromEntries(entries)
+
+    expect(object).toEqual({})
+  })
+})

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/fixtures/settingsForm.html
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/fixtures/settingsForm.html
@@ -2,387 +2,109 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Settings Form Fixture</title>
+    <title>Preferences Form Fixture</title>
 </head>
 <body>
 <form data-module="cookie-settings" data-on-value="on" data-off-value="off">
-
-
-
-
     <div class="govuk-form-group">
-
-        <fieldset class="govuk-fieldset"  aria-describedby="usage-hint" >
-
-
+        <fieldset class="govuk-fieldset" aria-describedby="usage-hint">
             <legend class="govuk-fieldset__legend">
                 <h2 class="govuk-heading-m">
                     Cookies that measure website use
                 </h2>
             </legend>
-
-
             <span id="usage-hint" class="govuk-hint">
-
-    <p class="govuk-body">We use Google Analytics to measure how you use the website so we can improve it based on user needs. We do not allow Google to use or share the data about how you use this site.</p>
-    <p class="govuk-body">Google Analytics sets cookies that store anonymised information about:</p>
-
-
+                <p class="govuk-body">We use Google Analytics to measure how you use the website so we can improve it based on user needs. We do not allow Google to use or share the data about how you use this site.</p>
+                <p class="govuk-body">Google Analytics sets cookies that store anonymised information about:</p>
                 </p>
                 <ul class="govuk-list govuk-list--bullet">
-        <li>how you got to the site</li>
-        <li>the pages you visit on HMRC services and how long you spend on each page</li>
-        <li>what you click on while youre visiting the site</li>
-    </ul>
-
-</span>
-
+                    <li>how you got to the site</li>
+                    <li>the pages you visit on HMRC services and how long you spend on each page</li>
+                    <li>what you click on while youre visiting the site</li>
+                </ul>
+            </span>
             <div class="govuk-radios">
-
-
-
-
-
-
-
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="usage" name="usage" type="radio" value="on"
-
-
-
-
-                    >
-
-
-
+                    <input class="govuk-radios__input" id="usage" name="usage" type="radio" value="on">
                     <label class="govuk-label govuk-radios__label" for="usage">
                         Use cookies that measure my website use
                     </label>
-
-
-
-
-
-
                 </div>
-
-
-
-
-
-
-
-
-
-
-
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="usage-2" name="usage" type="radio" value="off"
-
-
-
-
-                    >
-
-
-
+                    <input class="govuk-radios__input" id="usage-2" name="usage" type="radio" value="off">
                     <label class="govuk-label govuk-radios__label" for="usage-2">
                         Use cookies that measure my website use
                     </label>
-
-
-
-
-
-
                 </div>
-
-
-
-
-
             </div>
-
         </fieldset>
-
-
-
-
     </div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     <div class="govuk-form-group">
-
-        <fieldset class="govuk-fieldset"  aria-describedby="campaigns-hint" >
-
-
+        <fieldset class="govuk-fieldset" aria-describedby="campaigns-hint">
             <legend class="govuk-fieldset__legend">
-
                 <h2 class="govuk-heading-m">
                     Cookies that help with our communications and marketing
                 </h2>
-
             </legend>
-
-
             <span id="campaigns-hint" class="govuk-hint">
-  These cookies may be set by third party websites and do things like measure how you view YouTube videos that are on HMRC services.
-</span>
-
+                These cookies may be set by third party websites and do things like measure how you view YouTube videos that are on HMRC services.
+            </span>
             <div class="govuk-radios">
-
-
-
-
-
-
-
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="campaigns" name="campaigns" type="radio" value="on"
-
-
-
-
-                    >
-
-
-
+                    <input class="govuk-radios__input" id="campaigns" name="campaigns" type="radio" value="on">
                     <label class="govuk-label govuk-radios__label" for="campaigns">
                         Use cookies that remember my settings on the site
                     </label>
-
-
-
-
-
-
                 </div>
-
-
-
-
-
-
-
-
-
-
-
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="campaigns-2" name="campaigns" type="radio" value="off"
-
-
-
-
-                    >
-
-
-
+                    <input class="govuk-radios__input" id="campaigns-2" name="campaigns" type="radio" value="off">
                     <label class="govuk-label govuk-radios__label" for="campaigns-2">
                         Do not use cookies that remember my settings on the site
                     </label>
-
-
-
-
-
-
                 </div>
-
-
-
-
-
             </div>
-
         </fieldset>
-
-
-
-
     </div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     <div class="govuk-form-group">
-
-        <fieldset class="govuk-fieldset"  aria-describedby="settings-hint" >
-
-
+        <fieldset class="govuk-fieldset" aria-describedby="settings-hint">
             <legend class="govuk-fieldset__legend">
-
                 <h2 class="govuk-heading-m">Cookies that remember your settings</h2>
-
             </legend>
-
-
             <span id="settings-hint" class="govuk-hint">
-  These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.
-</span>
-
+              These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.
+            </span>
             <div class="govuk-radios">
-
-
-
-
-
-
-
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="settings" name="settings" type="radio" value="on"
-
-
-
-
-                    >
-
-
-
+                    <input class="govuk-radios__input" id="settings" name="settings" type="radio" value="on">
                     <label class="govuk-label govuk-radios__label" for="settings">
                         Use cookies that remember my settings on the site
                     </label>
-
-
-
-
-
-
                 </div>
-
-
-
-
-
-
-
-
-
-
-
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="settings-2" name="settings" type="radio" value="off"
-
-
-
-
-                    >
-
-
-
+                    <input class="govuk-radios__input" id="settings-2" name="settings" type="radio" value="off">
                     <label class="govuk-label govuk-radios__label" for="settings-2">
                         Do not use cookies that remember my settings on the site
                     </label>
-
-
-
-
-
-
                 </div>
-
-
-
-
-
             </div>
-
         </fieldset>
-
-
-
-
     </div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     <h2 class="govuk-heading-m">
         Strictly necessary cookies
     </h2>
-    <p class="govuk-body">These essential cookies do things like remember your progress through a form (for example a licence application)</p>
+    <p class="govuk-body">These essential cookies do things like remember your progress through a form (for example a
+        licence application)</p>
     <p class="govuk-body">They always need to be on.</p>
-    <p class="govuk-body"><p class="govuk-body">
-    <a href="/help/cookies?abc=def&amp;ghi=jkl">
-        Find out more about cookies on HMRC services
-    </a>
-</p></p>
-
-
-
-
-    <button
-
-            class="govuk-button" data-module="govuk-button">
+    <p class="govuk-body">
+    <p class="govuk-body">
+        <a href="/help/cookies?abc=def&amp;ghi=jkl">
+            Find out more about cookies on HMRC services
+        </a>
+    </p></p>
+    <button class="govuk-button" data-module="govuk-button">
         Save changes
-
     </button>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 </form>
-
 </body>
 </html>

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/settingsFormHandler.spec.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/settingsFormHandler.spec.ts
@@ -38,6 +38,22 @@ describe('User Preference Factory', () => {
   })
 
   describe('Initial state', () => {
+    it('should not fill before page load event fires', () => {
+      spyOn(testScope.userPref, 'getPreferences').and.returnValue({
+        usage: true,
+        campaigns: true,
+        settings: true
+      })
+      settingsFormHandler(testScope.document, testScope.userPref)
+
+      expect(testScope.document.querySelector('[name=usage][value=on]').checked).toBeFalsy()
+      expect(testScope.document.querySelector('[name=campaigns][value=on]').checked).toBeFalsy()
+      expect(testScope.document.querySelector('[name=settings][value=on]').checked).toBeFalsy()
+
+      expect(testScope.document.querySelector('[name=usage][value=off]').checked).toBeFalsy()
+      expect(testScope.document.querySelector('[name=campaigns][value=off]').checked).toBeFalsy()
+      expect(testScope.document.querySelector('[name=settings][value=off]').checked).toBeFalsy()
+    })
     it('should select all for user who has allowed all', () => {
       spyOn(testScope.userPref, 'getPreferences').and.returnValue({
         usage: true,
@@ -102,6 +118,21 @@ describe('User Preference Factory', () => {
       expect(testScope.document.querySelector('[name=campaigns][value=off]').checked).toBeTruthy()
       expect(testScope.document.querySelector('[name=settings][value=off]').checked).toBeFalsy()
     })
+    it('should select specific items for user who stored only a partial preference', () => {
+      spyOn(testScope.userPref, 'getPreferences').and.returnValue({
+        usage: true
+      })
+      settingsFormHandler(testScope.document, testScope.userPref)
+      pageLoad()
+
+      expect(testScope.document.querySelector('[name=usage][value=on]').checked).toBeTruthy()
+      expect(testScope.document.querySelector('[name=campaigns][value=on]').checked).toBeFalsy()
+      expect(testScope.document.querySelector('[name=settings][value=on]').checked).toBeFalsy()
+
+      expect(testScope.document.querySelector('[name=usage][value=off]').checked).toBeFalsy()
+      expect(testScope.document.querySelector('[name=campaigns][value=off]').checked).toBeFalsy()
+      expect(testScope.document.querySelector('[name=settings][value=off]').checked).toBeFalsy()
+    })
   })
   describe('saving preferences', () => {
     beforeEach(() => {
@@ -116,9 +147,7 @@ describe('User Preference Factory', () => {
       fireEvent.submit(testScope.document.querySelector('form'))
 
       expect(testScope.userPref.setPreferences).toHaveBeenCalledWith({
-        usage: true,
-        campaigns: false,
-        settings: false
+        usage: true
       })
     })
     it('should save when campaigns only is granted', () => {
@@ -129,23 +158,62 @@ describe('User Preference Factory', () => {
       fireEvent.submit(testScope.document.querySelector('form'))
 
       expect(testScope.userPref.setPreferences).toHaveBeenCalledWith({
-        usage: false,
-        campaigns: true,
-        settings: false
+        campaigns: true
       })
     })
-    it('should save when settings only is granted', () => {
+    it('should not store a value for items which don\'t appear in the form', () => {
       settingsFormHandler(testScope.document, testScope.userPref)
       pageLoad()
 
-      fireEvent.click(testScope.document.querySelector('[name=settings][value=on]'))
+      testScope.document.querySelectorAll('input[type=radio]:not([name=settings])').forEach(elem => {
+        elem.parentNode.removeChild(elem)
+      })
+
+      fireEvent.click(testScope.document.querySelector('[name=settings][value=off]'))
       fireEvent.submit(testScope.document.querySelector('form'))
 
       expect(testScope.userPref.setPreferences).toHaveBeenCalledWith({
-        usage: false,
-        campaigns: false,
-        settings: true
+        settings: false
       })
+    })
+  })
+  describe('Technical details', () => {
+    let pageLoadSync = () => {
+      throw new Error('No page load event to fire')
+    }
+
+    beforeEach(() => {
+      spyOn(testScope.document, 'addEventListener').and.callFake((name, fn) => {
+        // if (name === 'DOMContentLoaded') {
+        pageLoadSync = fn
+        // }
+      })
+    })
+
+    it('should error if the form doesn\'t have on value', () => {
+      testScope.document.querySelector('form[data-module=cookie-settings]').removeAttribute('data-on-value')
+      settingsFormHandler(testScope.document, testScope.userPref)
+
+      expect(() => {
+        pageLoadSync()
+      }).toThrowError(new Error('Could not initiate form without on value being set'))
+    })
+    it('should error if the form doesn\'t have off value', () => {
+      testScope.document.querySelector('form[data-module=cookie-settings]').removeAttribute('data-off-value')
+      settingsFormHandler(testScope.document, testScope.userPref)
+
+      expect(() => {
+        pageLoadSync()
+      }).toThrowError(new Error('Could not initiate form without off value being set'))
+    })
+    it('should default to the error message for the on value', () => {
+      testScope.document.querySelector('form[data-module=cookie-settings]').removeAttribute('data-off-value')
+      testScope.document.querySelector('form[data-module=cookie-settings]').removeAttribute('data-on-value')
+      settingsFormHandler(testScope.document, testScope.userPref)
+
+      expect(() => {
+        pageLoadSync()
+      }).toThrowError(new Error('Could not initiate form without on value being set'))
     })
   })
 })

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/types/Preferences.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/types/Preferences.ts
@@ -1,0 +1,6 @@
+export type Preferences = {
+    acceptAll?: boolean,
+    usage?: boolean,
+    campaigns?: boolean,
+    settings?: boolean
+}

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/types/UserPreferences.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/types/UserPreferences.ts
@@ -1,0 +1,7 @@
+import { Preferences } from './Preferences'
+
+export type UserPreferences = {
+    userAcceptsAll: () => void,
+    setPreferences: (Preferences) => void,
+    getPreferences: () => Preferences | undefined
+}


### PR DESCRIPTION
Replaced usage of querySelectorAll with querySelector for IE10 compatibility
Removed whitespace in test fixture
Added types and fixed type issues highlighted by type checks e.g. unsafe referencing of checked on nullable
Use ES6 string templates