### PR TITLE
BDOG-726: Enabling running with an assets prefix

### DIFF
--- a/app/uk/gov/hmrc/trackingconsentfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/config/AppConfig.scala
@@ -34,4 +34,5 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
   val reportAProblemPartialUrl: String = s"$contactBaseUrl/contact/problem_reports_ajax?service=$serviceIdentifier"
   val reportAProblemNonJSUrl: String   = s"$contactBaseUrl/contact/problem_reports_nonjs?service=$serviceIdentifier"
 
+  val cookieBannerAssetsPrefix: String = config.getOptional[String]("cookie-banner.assets-prefix").getOrElse("")
 }

--- a/app/uk/gov/hmrc/trackingconsentfrontend/views/ConsentHead.scala.html
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/views/ConsentHead.scala.html
@@ -21,4 +21,4 @@
 <!--[if lt IE 9]>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/es5-shim/4.5.7/es5-shim.min.js"></script>
 <![endif]-->
-<script type="text/javascript" src="@routes.Assets.versioned("bundle.js")"></script>
+<script type="text/javascript" src="@appConfig.cookieBannerAssetsPrefix@routes.Assets.versioned("bundle.js")"></script>


### PR DESCRIPTION
This means that running a service that calls tracking-consent-frontend
can specify the host & port in local development. Will be essential for
service-manager running too, so everything 'just works'