### PR TITLE
PLATUI-467: Add webpack watch to sbt run

### DIFF
--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/package.json
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/package.json
@@ -6,7 +6,7 @@
   "author": "HMRC",
   "license": "Apache-2.0",
   "scripts": {
-    "start": "NODE_ENV=develop webpack-dev-server --config ./webpack.config.js --mode development",
+    "start": "webpack --mode production --watch",
     "build": "webpack --mode production",
     "lint": "stylelint \"**/*.scss\" && standardx **/*.ts",
     "fixlint": "stylelint --fix \"**/*.scss\" && standardx --fix **/*.ts",

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 import play.sbt.PlayImport.PlayKeys.playDefaultPort
 
 val appName = "tracking-consent-frontend"
+val javaScriptDirectory = SettingKey[File]("javascriptDirectory")
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory)
@@ -22,6 +23,9 @@ lazy val microservice = Project(appName, file("."))
       "uk.gov.hmrc.govukfrontend.views.html.helpers._",
       "uk.gov.hmrc.hmrcfrontend.views.html.components._"
     )
+  )
+  .settings(
+    PlayKeys.playRunHooks += Webpack(JavaScriptBuild.javaScriptDirectory.value)
   )
   .settings(publishingSettings: _*)
   .configs(IntegrationTest)

--- a/project/Webpack.scala
+++ b/project/Webpack.scala
@@ -1,0 +1,31 @@
+import play.sbt.PlayRunHook
+import sbt._
+
+import scala.sys.process.Process
+
+object Webpack {
+  def apply(base: File): PlayRunHook = {
+
+    object WebpackProcess extends PlayRunHook {
+
+      var watchProcess: Option[Process] = None
+      val log = ConsoleLogger()
+
+      override def beforeStarted(): Unit = {
+        log.info("run npm install...")
+        Process("npm install", base).!
+
+        log.info("Starting webpack in watch mode...")
+        watchProcess = Some(Process("npm start", base).run)
+      }
+
+      override def afterStopped(): Unit = {
+        log.info("Shutting down webpack...")
+        watchProcess.map(p => p.destroy())
+        watchProcess = None
+      }
+    }
+
+    WebpackProcess
+  }
+}


### PR DESCRIPTION
This PR runs webpack in watch mode in the background while running sbt run as per https://www.playframework.com/documentation/2.6.16/SBTCookbook

Any changes to files in the Javascript directory trigger a rebuild of the bundles.