### PR TITLE
PLATUI-510: Make test server port configurable

### DIFF
--- a/test/acceptance/pages/CookieSettingsPage.scala
+++ b/test/acceptance/pages/CookieSettingsPage.scala
@@ -16,8 +16,8 @@
 
 package acceptance.pages
 
-import acceptance.conf.TestConfiguration
 import org.openqa.selenium.WebElement
+import support.TestConfiguration
 
 object CookieSettingsPage extends BasePage {
   val url: String = TestConfiguration.url("tracking-consent-frontend") + "/cookie-settings"

--- a/test/acceptance/pages/ServiceTestPage.scala
+++ b/test/acceptance/pages/ServiceTestPage.scala
@@ -16,8 +16,8 @@
 
 package acceptance.pages
 
-import acceptance.conf.TestConfiguration
 import org.openqa.selenium.WebElement
+import support.TestConfiguration
 
 object ServiceTestPage extends BasePage {
   val url: String          = TestConfiguration.url("tracking-consent-frontend") + "/test-only"

--- a/test/support/TestConfiguration.scala
+++ b/test/support/TestConfiguration.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package acceptance.conf
+package support
 
 import com.typesafe.config.{Config, ConfigFactory}
 

--- a/test/support/TestServer.scala
+++ b/test/support/TestServer.scala
@@ -21,9 +21,10 @@ import org.scalatestplus.play.BaseOneServerPerSuite
 import org.scalatestplus.play.guice.GuiceFakeApplicationFactory
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
+import TestConfiguration._
 
 trait TestServer extends BaseOneServerPerSuite with GuiceFakeApplicationFactory { this: TestSuite =>
-  override lazy val port = 12345
+  override lazy val port = servicePort("tracking-consent-frontend").toInt
 
   override implicit lazy val app: Application = new GuiceApplicationBuilder()
     .configure(

--- a/test/support/TestServer.scala
+++ b/test/support/TestServer.scala
@@ -30,7 +30,8 @@ trait TestServer extends BaseOneServerPerSuite with GuiceFakeApplicationFactory 
     .configure(
       Map(
         "metrics.enabled"  -> false,
-        "auditing.enabled" -> false
+        "auditing.enabled" -> false,
+        "cookie-banner.port" -> port
       )
     )
     .disable[com.kenshoo.play.metrics.PlayModule]


### PR DESCRIPTION
We need to be able to run the local test server on port 6001 in the build because only ports 6001 to 6010 are mapped back to the Jenkins build agent from the Chrome container.