### PR TITLE
PLATUI-510: Conditionally run test server

### DIFF
--- a/run_a11y_tests.sh
+++ b/run_a11y_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+sbt -mem 8192 \
+  -Dbrowser=remote-chrome \
+  -Denvironment=service-manager \
+  acceptance:test

--- a/run_acceptance_tests_dev.sh
+++ b/run_acceptance_tests_dev.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+sbt -mem 8192 \
+  -Dbrowser=remote-chrome \
+  -Denvironment=dev \
+  acceptance:test

--- a/test/acceptance/TestServerSpec.scala
+++ b/test/acceptance/TestServerSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package acceptance
+
+import java.net.{HttpURLConnection, URL}
+
+import org.scalatest.{BeforeAndAfterAll, Matchers, TryValues, WordSpec}
+import support.TestServer
+
+import scala.util.Try
+
+class TestServerSpec extends WordSpec with TestServer with Matchers with TryValues with BeforeAndAfterAll {
+  override lazy val port = 6001
+
+  val url = new URL(s"http://localhost:$port/tracking-consent/cookie-settings")
+  val expectedFailureMessage = "Connection refused (Connection refused)"
+
+  private def getTestPageResponseCode = {
+    val con = url.openConnection().asInstanceOf[HttpURLConnection]
+
+    try con.getResponseCode finally con.disconnect()
+  }
+
+  override def beforeAll() {
+    val connectionTry = Try { getTestPageResponseCode }
+
+    connectionTry.failure.exception should have message expectedFailureMessage
+  }
+
+  override def afterAll() {
+    val connectionTry = Try { getTestPageResponseCode }
+
+    connectionTry.failure.exception should have message expectedFailureMessage
+  }
+
+  "TestServer" should {
+    "create an HTTP endpoint" in {
+      val connectionTry = Try { getTestPageResponseCode }
+
+      connectionTry.success.value should be (200)
+    }
+  }
+}

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -24,6 +24,16 @@ local {
   }
 }
 
+service-manager {
+  services {
+    host: "http://localhost"
+    tracking-consent-frontend {
+      port = 12345
+      productionRoute = "/tracking-consent"
+    }
+  }
+}
+
 dev {
   services {
     host: "https://www.development.tax.service.gov.uk"


### PR DESCRIPTION
Run test server only if running locally (i.e. as part of initial build or on local development machine)
Add script to run a11y tests