### PR TITLE
PLATUI-573: Add compression and reduce TTL of assets from 3600 seconds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ lazy val microservice = Project(appName, file("."))
     ),
     PlayKeys.playRunHooks += Webpack(javaScriptDirectory.value),
     PlayKeys.devSettings ++= Seq("metrics.enabled"  -> "false", "auditing.enabled" -> "false"),
+    pipelineStages in Assets := Seq(gzip),
     acceptanceTestSettings,
     unitTestSettings,
     zapTestSettings,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -104,3 +104,7 @@ tracking-consent-frontend {
 # Add SHA hash to allow the Javascript-detection inline script from govuk-frontend to load without 'unsafe-inline':
 # https://github.com/hmrc/play-frontend-govuk/blob/f2eaff9c251bb13249fb8b7601ef726e5014bba0/src/main/play-26/twirl/uk/gov/hmrc/govukfrontend/views/layouts/govukTemplate.scala.html#L64
 play.filters.headers.contentSecurityPolicy = "default-src 'none'; script-src 'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' https://www.googletagmanager.com https://tagmanager.google.com https://www.google-analytics.com https://*.optimizely.com https://optimizely.s3.amazonaws.com https://cdn-assets-prod.s3.amazonaws.com data:; font-src 'self' https://ssl.gstatic.com https://www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com; style-src 'self' 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com; img-src 'self' https://ssl.gstatic.com https://www.gstatic.com https://www.googletagmanager.com https://www.google-analytics.com https://app.optimizely.com https://cdn.optimizely.com data:; frame-src 'self' https://www.googletagmanager.com; connect-src https://logx.optimizely.com https://*.optimizely.com;"
+
+play.assets.cache."/public/"="no-cache, max-age=0"
+play.assets.cache."/public/tracking.js"="public, max-age=60"
+play.assets.cache."/public/tracking-transitional.js"="public, max-age=60"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,3 +16,5 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.3.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")


### PR DESCRIPTION
Follow best practices for assets as per: https://www.playframework.com/documentation/2.7.x/AssetsOverview

Compress all assets using gzip
Reduce default TTL of assets from 3600 seconds to
- 60 seconds for tracking.js and tracking-transitional.js
- 0 seconds for the cookie settings page assets

In practice most requests will be using the Etag resulting in a 304 Not Modified response. Having a TTL > 0 for tracking.js will reduce the load on the server for this shared asset.