### PR TITLE
PLATUI-631: Fixes font-related console errors

### DIFF
--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/styles/_govuk-frontend.scss
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/styles/_govuk-frontend.scss
@@ -1,6 +1,11 @@
 // Cut down version of Gov UK Frontend 3.6.0
 // Styles prefixed to ensure banner is insulated from any other styles
 // in the page
+
+// Do not inject fonts, use the fonts available on the service page
+$govuk-include-default-font-face: false;
+$govuk-font-family: "GDS Transport", "nta", Arial, sans-serif;
+
 @import "node_modules/govuk-frontend/govuk/settings/all";
 @import "node_modules/govuk-frontend/govuk/helpers/all";
 @import "node_modules/govuk-frontend/govuk/tools/all";

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/styles/_typography.scss
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/styles/_typography.scss
@@ -3,7 +3,6 @@
 @import "node_modules/govuk-frontend/govuk/helpers/all";
 @import "node_modules/govuk-frontend/govuk/tools/all";
 
-$govuk-font-family: $govuk-font-family-gds-transport;
 $govuk-typography-use-rem: false;
 
 %govuk-heading-m {

--- a/app/uk/gov/hmrc/trackingconsentfrontend/testonly/controllers/LegacyTestController.scala
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/testonly/controllers/LegacyTestController.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.trackingconsentfrontend.testonly.controllers
+
+import javax.inject.{Inject, Singleton}
+import play.api.mvc._
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.hmrc.trackingconsentfrontend.config.AppConfig
+import uk.gov.hmrc.trackingconsentfrontend.testonly.views.html.LegacyTestPage
+
+import scala.concurrent.Future
+
+@Singleton
+class LegacyTestController @Inject()(appConfig: AppConfig, mcc: MessagesControllerComponents, legacyTestPage: LegacyTestPage)
+    extends FrontendController(mcc) {
+
+  implicit val config: AppConfig = appConfig
+
+  val legacyTest: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(legacyTestPage()))
+  }
+}

--- a/app/uk/gov/hmrc/trackingconsentfrontend/testonly/views/LegacyTestPage.scala.html
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/testonly/views/LegacyTestPage.scala.html
@@ -1,4 +1,4 @@
-/*
+@*
  * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,24 +12,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *@
 
-package zap
-
-import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.WordSpec
-import support.AcceptanceTestServer
-import uk.gov.hmrc.zap.ZapTest
-import uk.gov.hmrc.zap.config.ZapConfiguration
-
-class ZapScanSpec extends WordSpec with ZapTest with AcceptanceTestServer {
-  val zapConfig: Config = ConfigFactory.load().getConfig("zap-automation-config")
-
-  override val zapConfiguration: ZapConfiguration = new ZapConfiguration(zapConfig)
-
-  "Kicking off the zap scan" should {
-    "should complete successfully" in {
-      triggerZapScan()
-    }
-  }
-}
+@this(cookieHead: CookieHead)
+@()(implicit request: Request[_], appConfig: AppConfig)
+<html>
+    <head>
+        @cookieHead()
+    </head>
+    <body>
+        <h1>Legacy service test page</h1>
+    </body>
+</html>

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -12,5 +12,6 @@
 # Add all the application routes to the prod.routes file
 GET        /tracking-consent/test-only              uk.gov.hmrc.trackingconsentfrontend.testonly.controllers.TestController.test
 GET        /tracking-consent/test-only-transitional uk.gov.hmrc.trackingconsentfrontend.testonly.controllers.TransitionalTestController.transitionalTest
+GET        /tracking-consent/test-only-legacy       uk.gov.hmrc.trackingconsentfrontend.testonly.controllers.LegacyTestController.legacyTest
 
 ->         /             prod.Routes

--- a/test/acceptance/AcceptanceTestServerSpec.scala
+++ b/test/acceptance/AcceptanceTestServerSpec.scala
@@ -19,12 +19,12 @@ package acceptance
 import java.net.{ConnectException, HttpURLConnection, URL}
 
 import org.scalatest.{BeforeAndAfterAll, Matchers, TryValues, WordSpec}
-import support.TestServer
+import support.AcceptanceTestServer
 import support.TestConfiguration.env
 
 import scala.util.Try
 
-class TestServerSpec extends WordSpec with TestServer with Matchers with TryValues with BeforeAndAfterAll {
+class AcceptanceTestServerSpec extends WordSpec with AcceptanceTestServer with Matchers with TryValues with BeforeAndAfterAll {
   override lazy val port = 6001
 
   val url = new URL(s"http://localhost:$port/tracking-consent/cookie-settings?enableTrackingConsent=true")

--- a/test/acceptance/pages/BasePage.scala
+++ b/test/acceptance/pages/BasePage.scala
@@ -20,6 +20,7 @@ import acceptance.driver.BrowserDriver
 import org.openqa.selenium.{By, Cookie, WebElement}
 import org.scalatest.Matchers
 import org.scalatestplus.selenium.{Page, WebBrowser}
+import scala.collection.JavaConverters._
 
 trait BasePage extends Matchers with Page with WebBrowser with BrowserDriver {
   val url: String
@@ -35,4 +36,7 @@ trait BasePage extends Matchers with Page with WebBrowser with BrowserDriver {
   def settingsAllowedGtmEvent: AnyRef = findDataLayerEvent("hmrc-settings-allowed")
 
   def h1Element: WebElement = findBy(By.cssSelector("h1"))
+
+  def consoleErrors: Seq[String] =
+    driver.manage().logs().get("browser").asScala.map(_.getMessage).toSeq
 }

--- a/test/acceptance/pages/LegacyServiceTestPage.scala
+++ b/test/acceptance/pages/LegacyServiceTestPage.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package acceptance.pages
+
+import org.openqa.selenium.WebElement
+import support.TestConfiguration
+
+object LegacyServiceTestPage extends BasePage {
+  val url: String = TestConfiguration.url("tracking-consent-frontend") + "/test-only-legacy?enableTrackingConsent=true"
+
+  val title                = "Legacy service test page"
+  val acceptAllCookies     = "Accept all cookies"
+  val setCookiePreferences = "Set cookie preferences"
+
+  def acceptAllCookiesButton: WebElement     = findButtonByPartialText(acceptAllCookies)
+  def setCookiePreferencesButton: WebElement = findLabelByPartialText(setCookiePreferences)
+}

--- a/test/acceptance/specs/BaseAcceptanceSpec.scala
+++ b/test/acceptance/specs/BaseAcceptanceSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, FeatureSpec, GivenWhenThen, Matchers}
 import org.scalatestplus.selenium.WebBrowser
 import uk.gov.hmrc.webdriver.SingletonDriver
-import support.TestServer
+import support.AcceptanceTestServer
 
 import scala.util.Try
 
@@ -31,7 +31,7 @@ trait BaseAcceptanceSpec
     with BeforeAndAfterAll
     with Matchers
     with WebBrowser
-    with TestServer
+    with AcceptanceTestServer
     with BrowserDriver
     with Eventually {
 

--- a/test/acceptance/specs/CookieSettingsPageSpec.scala
+++ b/test/acceptance/specs/CookieSettingsPageSpec.scala
@@ -131,13 +131,13 @@ class CookieSettingsPageSpec extends BaseAcceptanceSpec {
     click on submitButton
 
     Then("the dataLayer contains the 'hmrc-measurement-allowed' event")
-    measurementAllowedGtmEvent should not be (null)
+    measurementAllowedGtmEvent should not be null
 
     And("the dataLayer contains the 'hmrc-marketing-allowed' event")
-    marketingAllowedGtmEvent should not be (null)
+    marketingAllowedGtmEvent should not be null
 
     And("the dataLayer contains the 'hmrc-settings-allowed' event")
-    settingsAllowedGtmEvent should not be (null)
+    settingsAllowedGtmEvent should not be null
 
     Then("the userConsent cookie is set")
     userConsentCookie.getValue should include(
@@ -166,5 +166,16 @@ class CookieSettingsPageSpec extends BaseAcceptanceSpec {
     Then("the userConsent cookie is set")
     userConsentCookie.getValue should include(
       "%22preferences%22:{%22measurement%22:true%2C%22marketing%22:true%2C%22settings%22:true}")
+  }
+
+  scenario("No Javascript errors occur") {
+    Given("the user clears their cookies")
+    deleteAllCookies
+
+    And("the user visits the cookie settings page")
+    go to CookieSettingsPage
+
+    Then("no Javascript console errors are thrown")
+    consoleErrors should equal (Seq.empty)
   }
 }

--- a/test/acceptance/specs/LegacyTestPageSpec.scala
+++ b/test/acceptance/specs/LegacyTestPageSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package acceptance.specs
+
+import acceptance.pages.LegacyServiceTestPage
+import acceptance.pages.LegacyServiceTestPage._
+
+class LegacyTestPageSpec extends BaseAcceptanceSpec {
+  feature("Legacy Service Test page") {
+    scenario("No Javascript errors occur") {
+      Given("the user clears their cookies")
+      deleteAllCookies
+
+      When("the user visits the legacy service test page with enable tracking consent parameter")
+      go to LegacyServiceTestPage
+
+      Then("the banner should be displayed with the title 'Tell us whether you accept cookies'")
+      eventually {
+        tagName("h2").element.text shouldBe "Tell us whether you accept cookies"
+      }
+
+      And("no Javascript console errors are thrown")
+      consoleErrors should equal (Seq.empty)
+    }
+  }
+}

--- a/test/acceptance/specs/ServiceTestPageSpec.scala
+++ b/test/acceptance/specs/ServiceTestPageSpec.scala
@@ -107,5 +107,21 @@ class ServiceTestPageSpec extends BaseAcceptanceSpec {
         tagName("h2").element.text shouldBe "Tell us whether you accept cookies"
       }
     }
+
+    scenario("No Javascript errors occur") {
+      Given("the user clears their cookies")
+      deleteAllCookies
+
+      When("the user visits the service test page with enable tracking consent parameter")
+      go to ServiceTestPageFeatureEnabled
+
+      And("the banner should be displayed with the title 'Tell us whether you accept cookies'")
+      eventually {
+        tagName("h2").element.text shouldBe "Tell us whether you accept cookies"
+      }
+
+      And("no Javascript console errors are thrown")
+      consoleErrors should equal (Seq.empty)
+    }
   }
 }

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka.event.slf4j.Slf4jLogger" level="WARN"/>
+
+    <logger name="com.google.inject" level="INFO"/>
+
+    <logger name="uk.gov" level="WARN"/>
+
+    <logger name="application" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/test/support/AcceptanceTestServer.scala
+++ b/test/support/AcceptanceTestServer.scala
@@ -23,7 +23,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import TestConfiguration._
 import play.api.test.TestServer
 
-trait TestServer extends TestSuiteMixin with GuiceFakeApplicationFactory { this: TestSuite =>
+trait AcceptanceTestServer extends TestSuiteMixin with GuiceFakeApplicationFactory { this: TestSuite =>
   lazy val port = servicePort("tracking-consent-frontend").toInt
 
   implicit lazy val app: Application = new GuiceApplicationBuilder()

--- a/test/unit/SpecBase.scala
+++ b/test/unit/SpecBase.scala
@@ -21,7 +21,7 @@ import org.jsoup.nodes.Document
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}
-import play.api.mvc.{Cookie, Cookies}
+import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import play.twirl.api.Html
 import uk.gov.hmrc.trackingconsentfrontend.config.AppConfig


### PR DESCRIPTION
Suppress unintended generation of @font-face rules linking to non-existent font assets
Use font-family with preference for GDS Transport falling back to nta, falling back to Arial
Add new test page reproducing issue and tests for console errors