### PR TITLE
Allow protocol-agnostic retrieval of GTM image as per https://develop…

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -115,7 +115,7 @@ play.filters.csp {
       # Unsafe inline for styles is required for GTM Preview
       style-src = "'self' 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com"
 
-      img-src = "'self' https://ssl.gstatic.com https://www.gstatic.com https://www.googletagmanager.com https://www.google-analytics.com https://app.optimizely.com https://cdn.optimizely.com data:"
+      img-src = "'self' https://ssl.gstatic.com https://www.gstatic.com www.googletagmanager.com https://www.google-analytics.com https://app.optimizely.com https://cdn.optimizely.com data:"
       frame-src = "'self' https://www.googletagmanager.com"
       connect-src = "https://tagmanager.google.com https://logx.optimizely.com https://*.optimizely.com"
     }

--- a/test/acceptance/specs/CookieSettingsPageSpec.scala
+++ b/test/acceptance/specs/CookieSettingsPageSpec.scala
@@ -167,4 +167,15 @@ class CookieSettingsPageSpec extends BaseAcceptanceSpec {
     userConsentCookie.getValue should include(
       "%22preferences%22:{%22measurement%22:true%2C%22marketing%22:true%2C%22settings%22:true}")
   }
+
+  scenario("No Javascript errors occur") {
+    Given("the user clears their cookies")
+    deleteAllCookies
+
+    And("the user visits the cookie settings page")
+    go to CookieSettingsPage
+
+    Then("no Javascript console errors are thrown")
+    consoleErrors should equal (Seq.empty)
+  }
 }


### PR DESCRIPTION
…ers.google.com/tag-manager/web/csp

Fixes console error issue with running acceptance tests locally
Re-instate console error check for cookie settings page