### PR TITLE
PLATUI-916: Passing through the query string.

### DIFF
--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/common/getReferrer.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/src/common/getReferrer.ts
@@ -2,7 +2,8 @@ const getReferrer = (): string => {
   if (typeof URL !== 'function') {
     return '';
   }
-  return document.referrer ? new URL(document.referrer).pathname : '';
+  const url = document.referrer && new URL(document.referrer);
+  return url ? `${url.pathname}${url.search}` : '';
 };
 
 export default getReferrer;

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/common/getReferrer.spec.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/common/getReferrer.spec.ts
@@ -4,6 +4,18 @@ describe('getReferrer', () => {
   let documentReferrer;
   Object.defineProperty(document, 'referrer', { get: () => documentReferrer });
 
+  it('should return an empty string if the URL is not a function (for IE10 compatibility)', () => {
+    const originalWindowUrl = window.URL;
+    documentReferrer = 'http://example.com/abc';
+    // @ts-ignore
+    window.URL = {};
+    const referrer = getReferrer();
+
+    expect(referrer).toEqual('');
+
+    window.URL = originalWindowUrl;
+  });
+
   it('should return just the pathname', () => {
     documentReferrer = 'https://www.tax.service.gov.uk/another-service';
 
@@ -12,17 +24,16 @@ describe('getReferrer', () => {
     expect(referrer).toEqual('/another-service');
   });
 
-  it('should return an empty string if no referrer has been set', () => {
-    documentReferrer = '';
+  it('should return just the pathname and query string', () => {
+    documentReferrer = 'https://www.tax.service.gov.uk/another-service?abc=def';
+
     const referrer = getReferrer();
 
-    expect(referrer).toEqual('');
+    expect(referrer).toEqual('/another-service?abc=def');
   });
 
-  it('should return an empty string if the URL is not a function (for IE10 compatibility)', () => {
-    documentReferrer = 'http://example.com/abc';
-    // @ts-ignore
-    window.URL = {};
+  it('should return an empty string if no referrer has been set', () => {
+    documentReferrer = '';
     const referrer = getReferrer();
 
     expect(referrer).toEqual('');

--- a/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/ui/renderSettingsSaveConfirmationMessage.spec.ts
+++ b/app/uk/gov/hmrc/trackingconsentfrontend/assets/test/ui/renderSettingsSaveConfirmationMessage.spec.ts
@@ -10,7 +10,7 @@ import * as getReferrer from '../../src/common/getReferrer';
 import * as getPathname from '../../src/common/getPathname';
 
 describe('renderSettingsSaveConfirmationMessage', () => {
-  let referrer = '/another-service';
+  let referrer = '/another-service?abc=def&ghi=jkl';
 
   beforeEach(() => {
     document.getElementsByTagName('html')[0].innerHTML = fixture;
@@ -50,7 +50,7 @@ describe('renderSettingsSaveConfirmationMessage', () => {
 
     // @ts-ignore
     const backLink: HTMLAnchorElement = getByText(document.body, /Go back to the page you were looking at/);
-    expect(backLink.href).toEqual('https://www.tax.service.example.com/another-service');
+    expect(backLink.href).toEqual('https://www.tax.service.example.com/another-service?abc=def&ghi=jkl');
   });
 
   it('should render the link inside a paragraph element', () => {


### PR DESCRIPTION
Passing through the query string, fixing issue with tests that stopped them from working in other orders.