### PR TITLE
DAST: Filter ZAP ruleID(cweId) 352.

### DIFF
--- a/alert-filters.json
+++ b/alert-filters.json
@@ -1,0 +1,8 @@
+{
+  "add": [
+    {
+      "url": "http://localhost:6001/tracking-consent/cookie-settings",
+      "ruleId": 352
+    }
+  ]
+}

--- a/alert-filters.json
+++ b/alert-filters.json
@@ -1,6 +1,7 @@
 {
   "add": [
     {
+      "reason": "CSRF tokens are not needed for this page because there is no server-side interaction",
       "url": "http://localhost:6001/tracking-consent/cookie-settings",
       "ruleId": 352
     }


### PR DESCRIPTION
CSRF tokens are not needed for this page because there is no server-side interaction. So silencing this alert.