### PR TITLE
PLATUI-1136: Uplift to Play 2.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import JavaScriptBuild._
-import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 import play.sbt.PlayImport.PlayKeys.playDefaultPort
 import sbt.Keys.testOptions
-import uk.gov.hmrc.DefaultBuildSettings.{addTestReportOption, integrationTestSettings}
+import uk.gov.hmrc.DefaultBuildSettings.addTestReportOption
+import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 
 val appName = "tracking-consent-frontend"
 
@@ -46,7 +46,7 @@ lazy val zapTestSettings =
     )
 
 lazy val microservice = Project(appName, file("."))
-  .enablePlugins(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin)
+  .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .configs(AcceptanceTest, IntegrationTest, ZapTest)
   .settings(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,16 +4,16 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-27" % "4.1.0",
-    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "0.56.0-play-27"
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "5.3.0",
+    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "0.63.0-play-28"
   )
 
   val test = Seq(
     "org.jsoup"               % "jsoup"              % "1.10.2" % "test",
     "com.typesafe.play"      %% "play-test"          % current  % "test",
     "org.pegdown"             % "pegdown"            % "1.6.0"  % "test",
-    "org.scalatest"          %% "scalatest"          % "3.0.8"  % "test",
-    "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3"  % "test",
+    "org.scalatest"          %% "scalatest"          % "3.0.9"  % "test",
+    "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0"  % "test",
     "uk.gov.hmrc"            %% "webdriver-factory"  % "0.16.0" % "test",
     "uk.gov.hmrc"            %% "zap-automation"     % "2.8.0"  % "test",
     "com.typesafe"            % "config"             % "1.3.2"  % "test",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.6
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,20 +1,16 @@
-resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(
+resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
+resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
   Resolver.ivyStylePatterns
 )
-
-resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
-
 resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.11")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.13.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.7")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 


### PR DESCRIPTION
I found that to update sbt-auto-build I had to update the plugin resolvers to the new open artefact store (https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=256476338 which may need a ticket creating to apply change to other repositories we own, because I couldn't see one beside the test leads tickets)