### PR TITLE
Update the sbt-accessibility plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import JavaScriptBuild._
 import play.sbt.PlayImport.PlayKeys.playDefaultPort
 import sbt.Keys.testOptions
+import uk.gov.hmrc.AccessibilityLinterPlugin.autoImport.A11yTest
 import uk.gov.hmrc.DefaultBuildSettings.addTestReportOption
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 
@@ -69,6 +70,7 @@ lazy val microservice = Project(appName, file("."))
     libraryDependencies ++= Seq(
       compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.6.0" cross CrossVersion.full),
       "com.github.ghik" % "silencer-lib" % "1.6.0" % Provided cross CrossVersion.full
-    )
+    ),
     // ***************
+    A11yTest / unmanagedSourceDirectories += (baseDirectory.value / "test" / "a11y")
   )

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -29,7 +29,7 @@ sbt run
 ## Running all Scala and Javascript unit and integration tests together
 
 ```
-sbt a11yTest it:test
+sbt a11y:test it:test
 ```
 
 The above tests include accessibility checks via the

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -29,7 +29,7 @@ sbt run
 ## Running all Scala and Javascript unit and integration tests together
 
 ```
-sbt a11y:test it:test
+sbt test a11y:test it:test
 ```
 
 The above tests include accessibility checks via the

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,4 +16,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-accessibility-linter" % "0.14.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-accessibility-linter" % "0.17.0")

--- a/test/a11y/CookieSettingsSpec.scala
+++ b/test/a11y/CookieSettingsSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package a11y
+
+import uk.gov.hmrc.scalatestaccessibilitylinter.AccessibilityMatchers
+import uk.gov.hmrc.trackingconsentfrontend.views.html.CookieSettingsPage
+import unit.SpecBase
+
+class CookieSettingsSpec extends SpecBase with AccessibilityMatchers {
+
+  "the cookie settings page" must {
+    val cookieSettingsPage = app.injector.instanceOf[CookieSettingsPage]
+    val content            = cookieSettingsPage()
+
+    "should pass accessibility checks" in {
+      content.toString() must passAccessibilityChecks
+    }
+  }
+}

--- a/test/unit/SpecBase.scala
+++ b/test/unit/SpecBase.scala
@@ -21,10 +21,9 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.i18n.Messages
 import play.api.inject.guice.GuiceApplicationBuilder
-import uk.gov.hmrc.scalatestaccessibilitylinter.AccessibilityMatchers
 import uk.gov.hmrc.trackingconsentfrontend.config.AppConfig
 
-trait SpecBase extends PlaySpec with GuiceOneAppPerSuite with JsoupHelpers with AppHelpers with AccessibilityMatchers {
+trait SpecBase extends PlaySpec with GuiceOneAppPerSuite with JsoupHelpers with AppHelpers {
 
   val baseProperties: Map[String, Any] = Map(
     "optimizely.url"       -> "https://cdn.optimizely.com/",

--- a/test/unit/views/CookieSettingsSpec.scala
+++ b/test/unit/views/CookieSettingsSpec.scala
@@ -25,10 +25,6 @@ class CookieSettingsSpec extends SpecBase {
     val cookieSettingsPage = app.injector.instanceOf[CookieSettingsPage]
     val content            = cookieSettingsPage()
 
-    "should pass accessibility checks" in {
-      content.toString() must passAccessibilityChecks
-    }
-
     "display the correct browser title" in {
       content.select("title").text mustBe "Cookie settings on HMRC services – GOV.UK"
     }


### PR DESCRIPTION
I have left the accessibility checks in the `acceptance` tests as i feel they should remain part of acceptance testing.

NOTE: The build is expected to fail because build-jobs is still set to run the sbt task a11yTest which has been removed in the latest sbt-accessibility-linter plugin.

We will need to update the build-jobs after this PR is merged in.