### PR TITLE
NOJIRA npm audit - update to use GHSA ID instead of NPM ID which is apparently mutable

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,10 +1,10 @@
 {
-  "1070904": "jpeg-js: devDependency, no risk given our usage",
-  "1070022": "node-fetch: devDependency, no risk given our usage",
-  "1070417": "semver-regex: devDependency, no risk given our usage",
-  "1070458": "semver-regex: devDependency, no risk given our usage",
-  "1067342": "minimist: devDependency, no risk given our usage",
-  "1067367": "nanoid: devDependency, no risk given our usage",
-  "1070274": "ansi-regex: devDependency, no risk given our usage",
-  "1070440": "async: devDependency, no risk given our usage"
+  "https://github.com/advisories/GHSA-xvf7-4v9q-58w6": "jpeg-js: devDependency, no risk given our usage",
+  "https://github.com/advisories/GHSA-r683-j2x4-v87g": "node-fetch: devDependency, no risk given our usage",
+  "https://github.com/advisories/GHSA-44c6-4v22-4mhx": "semver-regex: devDependency, no risk given our usage",
+  "https://github.com/advisories/GHSA-4x5v-gmq8-25ch": "semver-regex: devDependency, no risk given our usage",
+  "https://github.com/advisories/GHSA-xvch-5gv4-984h": "minimist: devDependency, no risk given our usage",
+  "https://github.com/advisories/GHSA-qrpm-p2h7-hrv2": "nanoid: devDependency, no risk given our usage",
+  "https://github.com/advisories/GHSA-93q8-gq69-wqmw": "ansi-regex: devDependency, no risk given our usage",
+  "https://github.com/advisories/GHSA-fwr7-v2mv-hh25": "async: devDependency, no risk given our usage"
 }


### PR DESCRIPTION
…pparently mutable