### PR TITLE
PLATUI-2109 retry flickering tests; fix some given/when/then oddities

### DIFF
--- a/test/acceptance/pages/BasePage.scala
+++ b/test/acceptance/pages/BasePage.scala
@@ -50,7 +50,6 @@ trait BasePage extends Matchers with Page with WebBrowser with BrowserDriver {
     logs
       .filter(_.getLevel == SEVERE)
       .map(_.getMessage)
-      .filterNot(_.contains("favicon.ico")) // TODO: temporary fix for bug ticket PLATUI-2109
       .toSeq
   }
 

--- a/test/acceptance/specs/BaseAcceptanceSpec.scala
+++ b/test/acceptance/specs/BaseAcceptanceSpec.scala
@@ -18,9 +18,10 @@ package acceptance.specs
 
 import acceptance.driver.BrowserDriver
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{BeforeAndAfterAll, GivenWhenThen}
+import org.scalatest.{BeforeAndAfterAll, GivenWhenThen, Outcome, Retries}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.time.{Seconds, Span}
 import org.scalatestplus.selenium.WebBrowser
 import support.AcceptanceTestServer
 import uk.gov.hmrc.scalatestaccessibilitylinter.AccessibilityMatchers
@@ -36,6 +37,7 @@ trait BaseAcceptanceSpec
     with WebBrowser
     with AcceptanceTestServer
     with BrowserDriver
+    with Retries
     with Eventually
     with AccessibilityMatchers {
 
@@ -50,4 +52,10 @@ trait BaseAcceptanceSpec
       Try(SingletonDriver.closeInstance())
     }
   }
+
+  override def withFixture(test: NoArgTest): Outcome =
+    if (isRetryable(test))
+      withRetry(Span(2L, Seconds))(super.withFixture(test))
+    else
+      super.withFixture(test)
 }

--- a/test/acceptance/specs/CookieSettingsPageSpec.scala
+++ b/test/acceptance/specs/CookieSettingsPageSpec.scala
@@ -19,6 +19,7 @@ package acceptance.specs
 import acceptance.pages.CookieSettingsPage
 import acceptance.pages.CookieSettingsPage._
 import acceptance.specs.tags.Local
+import org.scalatest.tagobjects.Retryable
 
 class CookieSettingsPageSpec extends BaseAcceptanceSpec {
 
@@ -64,7 +65,7 @@ class CookieSettingsPageSpec extends BaseAcceptanceSpec {
     Then("the consent setting 'Use cookies that measure my website use' is selected")
     useMeasurementCookiesInput.isSelected should be(true)
 
-    Then("the consent setting 'Use cookies that remember my settings on the site' is selected")
+    And("the consent setting 'Use cookies that remember my settings on the site' is selected")
     useSettingsCookiesInput.isSelected should be(true)
   }
 
@@ -90,7 +91,7 @@ class CookieSettingsPageSpec extends BaseAcceptanceSpec {
     Then("the consent setting 'Do not use cookies that measure my website use' is selected")
     doNotUseMeasurementCookiesInput.isSelected should be(true)
 
-    Then("the consent setting 'Do not use cookies that remember my settings on the site' is selected")
+    And("the consent setting 'Do not use cookies that remember my settings on the site' is selected")
     doNotUseSettingsCookiesInput.isSelected should be(true)
   }
 
@@ -115,11 +116,6 @@ class CookieSettingsPageSpec extends BaseAcceptanceSpec {
 
     And("the dataLayer contains the 'trackingConsentSettingsAccepted' event")
     settingsAllowedGtmEvent should not be null
-
-    Then("the userConsent cookie is set")
-    userConsentCookie.getValue should include(
-      "%22preferences%22:{%22measurement%22:true%2C%22settings%22:true}"
-    )
   }
 
   Scenario("The user granting consent for all cookies sets the userConsent cookie") {
@@ -192,11 +188,11 @@ class CookieSettingsPageSpec extends BaseAcceptanceSpec {
     h3Element.getText                 shouldBe "Wedi cadw’ch gosodiadau cwcis"
   }
 
-  Scenario("No Javascript errors occur") {
+  Scenario("No Javascript errors occur", Retryable) {
     Given("the user clears their cookies")
     deleteAllCookies()
 
-    And("the user visits the cookie settings page")
+    When("the user visits the cookie settings page")
     go to CookieSettingsPage
 
     Then("no Javascript console errors are thrown")

--- a/test/acceptance/specs/LegacyTestPageSpec.scala
+++ b/test/acceptance/specs/LegacyTestPageSpec.scala
@@ -18,10 +18,11 @@ package acceptance.specs
 
 import acceptance.pages.LegacyServiceTestPage
 import acceptance.pages.LegacyServiceTestPage._
+import org.scalatest.tagobjects.Retryable
 
 class LegacyTestPageSpec extends BaseAcceptanceSpec {
   Feature("Legacy Service Test page") {
-    Scenario("No Javascript errors occur") {
+    Scenario("No Javascript errors occur", Retryable) {
       Given("the user clears their cookies")
       deleteAllCookies()
 

--- a/test/acceptance/specs/ServiceTestPageSpec.scala
+++ b/test/acceptance/specs/ServiceTestPageSpec.scala
@@ -19,6 +19,7 @@ package acceptance.specs
 import acceptance.pages.ServiceTestPage
 import acceptance.pages.ServiceTestPage._
 import acceptance.specs.tags.Local
+import org.scalatest.tagobjects.Retryable
 
 class ServiceTestPageSpec extends BaseAcceptanceSpec {
   Feature("Service Test page") {
@@ -54,7 +55,7 @@ class ServiceTestPageSpec extends BaseAcceptanceSpec {
       Given("the user clears their cookies")
       deleteAllCookies()
 
-      When("the user visits the service test page")
+      And("the user visits the service test page")
       go to ServiceTestPage
       eventually {
         tagName("h2").element.text shouldBe "Cookies on HMRC services"
@@ -74,7 +75,7 @@ class ServiceTestPageSpec extends BaseAcceptanceSpec {
       Given("the user clears their cookies")
       deleteAllCookies()
 
-      When("the user visits the service test page")
+      And("the user visits the service test page")
       go to ServiceTestPage
       eventually {
         tagName("h2").element.text shouldBe "Cookies on HMRC services"
@@ -97,7 +98,7 @@ class ServiceTestPageSpec extends BaseAcceptanceSpec {
       Given("the user clears their cookies")
       deleteAllCookies()
 
-      When("the user visits the service test page")
+      And("the user visits the service test page")
       go to ServiceTestPage
 
       When("the user clicks 'Accept all cookies'")
@@ -111,7 +112,7 @@ class ServiceTestPageSpec extends BaseAcceptanceSpec {
       Given("the user clears their cookies")
       deleteAllCookies()
 
-      When("the user visits the service test page")
+      And("the user visits the service test page")
       go to ServiceTestPage
 
       When("the user clicks 'Accept all cookies'")
@@ -125,7 +126,7 @@ class ServiceTestPageSpec extends BaseAcceptanceSpec {
       Given("the user clears their cookies")
       deleteAllCookies()
 
-      When("the user visits the service test page")
+      And("the user visits the service test page")
       go to ServiceTestPage
 
       When("the user clicks 'Accept all cookies'")
@@ -151,14 +152,14 @@ class ServiceTestPageSpec extends BaseAcceptanceSpec {
       }
     }
 
-    Scenario("No Javascript errors occur") {
+    Scenario("No Javascript errors occur", Retryable) {
       Given("the user clears their cookies")
       deleteAllCookies()
 
       When("the user visits the service test page")
       go to ServiceTestPage
 
-      And("the banner should be displayed with the title 'Cookies on HMRC services'")
+      Then("the banner should be displayed with the title 'Cookies on HMRC services'")
       eventually {
         tagName("h2").element.text shouldBe "Cookies on HMRC services"
       }
@@ -174,7 +175,7 @@ class ServiceTestPageSpec extends BaseAcceptanceSpec {
       When("the user visits the service test page")
       go to ServiceTestPage
 
-      And("the banner should be displayed with the title 'Cookies on HMRC services'")
+      Then("the banner should be displayed with the title 'Cookies on HMRC services'")
       eventually {
         tagName("h2").element.text shouldBe "Cookies on HMRC services"
       }
@@ -187,7 +188,7 @@ class ServiceTestPageSpec extends BaseAcceptanceSpec {
       Given("the user clears their cookies")
       deleteAllCookies()
 
-      When("the user visits the service test page")
+      And("the user visits the service test page")
       go to ServiceTestPage
       eventually {
         tagName("h2").element.text shouldBe "Cookies on HMRC services"


### PR DESCRIPTION
From a bit of searching, it seems that the 502 Bad Gateway error may indicate a cache problem with the browser.  Rather than go down a rabbit hole trying to diagnose and fix that, I've added code to retry any tests that fail and have the `Retryable` tag. 