### PR TITLE
PLATUI-2683 sets public directory cache max-age to 1 hour

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -83,9 +83,7 @@ tracking-consent-frontend {
   url = "http://localhost:12345/tracking-consent/tracking.js"
 }
 
-play.assets.cache."/public/"="no-cache, max-age=0"
-play.assets.cache."/public/tracking.js"="public, max-age=60"
-play.assets.cache."/public/tracking/"="public, max-age=60"
+play.assets.cache."/public/"="public, max-age=3600"
 
 play.filters.cors {
   allowedHttpMethods = ["POST", "OPTIONS"]


### PR DESCRIPTION
# Purpose of PR
[This PR](https://github.com/hmrc/tracking-consent-frontend/pull/65) added caching explicitly for tracking.js in the `/public/` directory. This was before `optimizely.js` was added to the same directory. At the time, it seems it was set to explicitly set `no-cache` on anything that wasn't `tracking.js`.

Now we want to cache `optimizely.js`, we feel it's more appropriate to set caching on the public directory. This is because our caching rules are also applying to `hmrcfrontend.routes` assets. As such, instead of explicitly setting `optimizely.js`, set the whole directory's cache control headers to `public, max-age=3600` so that users don't need to revalidate after most page visits.