### PR TITLE
PLATUI-3063 update js-cookie and refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ stats.json
 **/backstop_data/bitmaps_test
 /backstop.config-for-docker.json
 .bsp
+.bloop/
+.metals/
+.vscode/
+project/.bloop/
+project/metals.sbt

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -14,34 +14,12 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/access.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/connector.log</file>
         <encoder>
             <pattern>%message%n</pattern>
         </encoder>
     </appender>
-
-
-    <logger name="accesslog" level="INFO" additivity="false">
-        <appender-ref ref="ACCESS_LOG_FILE" />
-    </logger>
-
-    <logger name="com.ning.http.client.providers.netty" additivity="false">
-        <appender-ref ref="STDOUT_IGNORE_NETTY" />
-    </logger>
 
     <logger name="com.google.inject" level="INFO"/>
 

--- a/js/src/domain/userPreferencesFactory.ts
+++ b/js/src/domain/userPreferencesFactory.ts
@@ -76,21 +76,6 @@ const userPreferencesFactory = (): UserPreferences => {
     return cookie;
   };
 
-  // const validateCookie = (): Cookie | undefined => {
-  //  let cookie = Cookies.get(COOKIE_CONSENT)
-  //  if (cookie === null || cookie === undefined || cookie.preferences === undefined) {
-  //    return undefined;
-  //  }
-  //  let cookieJson = JSON.parse(cookie);
-
-  //  const { version } = cookie;
-  //  if (version !== COOKIE_VERSION) {
-  //    return undefined;
-  //  }
-
-  //  return cookie;
-  // };
-
   const getPreferences = (): Preferences | undefined => {
     const cookie = validateCookie();
     if (cookie === undefined) {

--- a/js/src/domain/userPreferencesFactory.ts
+++ b/js/src/domain/userPreferencesFactory.ts
@@ -21,15 +21,15 @@ const userPreferencesFactory = (): UserPreferences => {
   };
 
   const storePreferences = (preferences: Preferences) => {
-    Cookies.set(
-      COOKIE_CONSENT,
+    Cookies.set(COOKIE_CONSENT,
       {
         version: COOKIE_VERSION,
         datetimeSet: new Date().toISOString(),
         preferences,
-      },
-      { sameSite: 'strict', expires: 365 },
-    );
+      }, {
+        sameSite: 'strict',
+        expires: 365,
+      });
   };
 
   const allThePreferences = (hasConsented: boolean) => fromEntries(cookieTypes.map(
@@ -63,7 +63,7 @@ const userPreferencesFactory = (): UserPreferences => {
   };
 
   const validateCookie = (): Cookie | undefined => {
-    const cookie = Cookies.getJSON(COOKIE_CONSENT);
+    const cookie = Cookies.get(COOKIE_CONSENT);
     if (cookie === null || cookie === undefined || cookie.preferences === undefined) {
       return undefined;
     }
@@ -75,6 +75,21 @@ const userPreferencesFactory = (): UserPreferences => {
 
     return cookie;
   };
+
+  // const validateCookie = (): Cookie | undefined => {
+  //  let cookie = Cookies.get(COOKIE_CONSENT)
+  //  if (cookie === null || cookie === undefined || cookie.preferences === undefined) {
+  //    return undefined;
+  //  }
+  //  let cookieJson = JSON.parse(cookie);
+
+  //  const { version } = cookie;
+  //  if (version !== COOKIE_VERSION) {
+  //    return undefined;
+  //  }
+
+  //  return cookie;
+  // };
 
   const getPreferences = (): Preferences | undefined => {
     const cookie = validateCookie();

--- a/js/src/domain/userPreferencesFactory.ts
+++ b/js/src/domain/userPreferencesFactory.ts
@@ -22,11 +22,11 @@ const userPreferencesFactory = (): UserPreferences => {
 
   const storePreferences = (preferences: Preferences) => {
     Cookies.set(COOKIE_CONSENT,
-      {
+      JSON.stringify({
         version: COOKIE_VERSION,
         datetimeSet: new Date().toISOString(),
         preferences,
-      }, {
+      }), {
         sameSite: 'strict',
         expires: 365,
       });
@@ -63,17 +63,21 @@ const userPreferencesFactory = (): UserPreferences => {
   };
 
   const validateCookie = (): Cookie | undefined => {
-    const cookie = Cookies.get(COOKIE_CONSENT);
-    if (cookie === null || cookie === undefined || cookie.preferences === undefined) {
+    try {
+      const cookie = JSON.parse(Cookies.get(COOKIE_CONSENT));
+      if (cookie === null || cookie === undefined || cookie.preferences === undefined) {
+        return undefined;
+      }
+
+      const { version } = cookie;
+      if (version !== COOKIE_VERSION) {
+        return undefined;
+      }
+
+      return cookie;
+    } catch (e) {
       return undefined;
     }
-
-    const { version } = cookie;
-    if (version !== COOKIE_VERSION) {
-      return undefined;
-    }
-
-    return cookie;
   };
 
   const getPreferences = (): Preferences | undefined => {

--- a/js/test/domain/userPreferencesFactory.spec.ts
+++ b/js/test/domain/userPreferencesFactory.spec.ts
@@ -17,7 +17,7 @@ describe('userPreferencesFactory', () => {
     spyOn(Cookies, 'set').and.callFake((cookieName, value) => {
       testScope.cookieData[cookieName] = value;
     });
-    spyOn(Cookies, 'getJSON').and.callFake((cookieName) => testScope.cookieData[cookieName]);
+    spyOn(Cookies, 'get').and.callFake((cookieName) => testScope.cookieData[cookieName]);
     spyOn(Date.prototype, 'toISOString').and.callFake(() => testScope.fakeDatetime);
   });
 
@@ -363,13 +363,13 @@ describe('userPreferencesFactory', () => {
       expect(new Date().toISOString()).toEqual(123);
     });
     it('cookies should be settable and gettable', () => {
-      expect(Cookies.getJSON('abcdef')).toBeUndefined();
+      expect(Cookies.get('abcdef')).toBeUndefined();
       Cookies.set('abcdef', 'this is my cookie value');
-      expect(Cookies.getJSON('abcdef')).toBe('this is my cookie value');
+      expect(Cookies.get('abcdef')).toBe('this is my cookie value');
     });
     it('cookies should be settable with an object', () => {
-      Cookies.set('abcdef', { thisIs: 'AnObject' });
-      expect(Cookies.getJSON('abcdef')).toEqual({ thisIs: 'AnObject' });
+      Cookies.set('abcdef', JSON.stringify({ thisIs: 'AnObject' }));
+      expect(JSON.parse(Cookies.get('abcdef'))).toEqual({ thisIs: 'AnObject' });
     });
   });
 });

--- a/js/test/domain/userPreferencesFactory.spec.ts
+++ b/js/test/domain/userPreferencesFactory.spec.ts
@@ -22,11 +22,11 @@ describe('userPreferencesFactory', () => {
   });
 
   const setConsentCookie = (obj) => {
-    testScope.cookieData.userConsent = { version: '2021.1', ...obj };
+    testScope.cookieData.userConsent = JSON.stringify({ version: '2021.1', ...obj });
   };
 
   const expectTrackingPreferenceToHaveBeenSetWith = (preference) => {
-    expect(Cookies.set).toHaveBeenCalledWith('userConsent', preference, expect.anything());
+    expect(Cookies.set).toHaveBeenCalledWith('userConsent', JSON.stringify(preference), expect.anything());
     expect(Cookies.set).toHaveBeenCalledTimes(1);
   };
 
@@ -264,40 +264,40 @@ describe('userPreferencesFactory', () => {
         measurement: true,
         settings: true,
       });
-      expect(Cookies.set).toHaveBeenCalledWith('userConsent', {
+      expect(Cookies.set).toHaveBeenCalledWith('userConsent', JSON.stringify({
         version: '2021.1',
         datetimeSet: testScope.fakeDatetime,
         preferences: {
           measurement: true,
           settings: true,
         },
-      }, { sameSite: 'strict', expires: 365 });
+      }), { sameSite: 'strict', expires: 365 });
     });
     it('should save other preferences to the cookie', () => {
       testScope.userPreference.setPreferences({
         measurement: false,
         settings: true,
       });
-      expect(Cookies.set).toHaveBeenCalledWith('userConsent', {
+      expect(Cookies.set).toHaveBeenCalledWith('userConsent', JSON.stringify({
         version: '2021.1',
         datetimeSet: testScope.fakeDatetime,
         preferences: {
           measurement: false,
           settings: true,
         },
-      }, { sameSite: 'strict', expires: 365 });
+      }), { sameSite: 'strict', expires: 365 });
     });
     it('should save only preferences specified', () => {
       testScope.userPreference.setPreferences({
         measurement: true,
       });
-      expect(Cookies.set).toHaveBeenCalledWith('userConsent', {
+      expect(Cookies.set).toHaveBeenCalledWith('userConsent', JSON.stringify({
         version: '2021.1',
         datetimeSet: testScope.fakeDatetime,
         preferences: {
           measurement: true,
         },
-      }, { sameSite: 'strict', expires: 365 });
+      }), { sameSite: 'strict', expires: 365 });
     });
 
     it('should call preference communicator', () => {
@@ -366,10 +366,6 @@ describe('userPreferencesFactory', () => {
       expect(Cookies.get('abcdef')).toBeUndefined();
       Cookies.set('abcdef', 'this is my cookie value');
       expect(Cookies.get('abcdef')).toBe('this is my cookie value');
-    });
-    it('cookies should be settable with an object', () => {
-      Cookies.set('abcdef', JSON.stringify({ thisIs: 'AnObject' }));
-      expect(JSON.parse(Cookies.get('abcdef'))).toEqual({ thisIs: 'AnObject' });
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "css-loader": "7.1.1",
         "dot-properties": "1.0.1",
         "govuk-frontend": "5.3.0",
-        "js-cookie": "2.2.1",
+        "js-cookie": "^3.0.5",
         "postcss": "^8.1.0",
         "style-loader": "4.0.0",
         "ts-loader": "9.4.1",
@@ -15179,9 +15179,12 @@
       "dev": true
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "css-loader": "7.1.1",
     "dot-properties": "1.0.1",
     "govuk-frontend": "5.3.0",
-    "js-cookie": "2.2.1",
+    "js-cookie": "^3.0.5",
     "postcss": "^8.1.0",
     "style-loader": "4.0.0",
     "ts-loader": "9.4.1",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -15,6 +15,6 @@ object AppDependencies {
     "org.jsoup"          % "jsoup"                        % "1.15.4"         % Test,
     "uk.gov.hmrc"       %% s"bootstrap-test-$playVersion" % bootstrapVersion % Test,
     "org.scalatestplus" %% "selenium-4-12"                % "3.2.17.0"       % Test,
-    "uk.gov.hmrc"       %% "ui-test-runner"               % "0.26.0"         % Test
+    "uk.gov.hmrc"       %% "ui-test-runner"               % "0.30.0"         % Test
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 resolvers += Resolver.typesafeRepo("releases")
 
 // If re-ordering plugins, we noticed in upgrading to Play 3 that builds broke with previous order plugins were added
-addSbtPlugin("uk.gov.hmrc"        % "sbt-auto-build"           % "3.21.0")
+addSbtPlugin("uk.gov.hmrc"        % "sbt-auto-build"           % "3.22.0")
 addSbtPlugin("uk.gov.hmrc"        % "sbt-distributables"       % "2.5.0")
 addSbtPlugin("org.playframework"  % "sbt-plugin"               % "3.0.2")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-gzip"                 % "1.0.2")


### PR DESCRIPTION
# Purpose of PR
To bump the version of js-cookie, the update is to a new major version of the library, removing a few methods:

- `getJSON()` is now `Cookies.get('foo')`, wrapped in a `JSON.parse()`.
- `set()` now doesn't automatically stringify JSON.