### PR TITLE
PLATUI-3318 bump scala version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val acceptanceTestSettings =
 lazy val sharedSettings = Seq(
   libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
   majorVersion := 1,
-  scalaVersion := "3.3.3"
+  scalaVersion := "3.3.4"
 )
 
 lazy val microservice = Project(appName, file("."))
@@ -55,7 +55,7 @@ lazy val microservice = Project(appName, file("."))
     unitTestSettings,
     javaScriptSettings,
     scalacOptions += "-Wconf:src=routes/.*:s",
-    scalacOptions += "-Wconf:cat=unused-imports&src=html/.*:s"
+    scalacOptions += "-Wconf:msg=unused-imports&src=html/.*:s"
   )
 
 lazy val it = project


### PR DESCRIPTION
# Purpose of PR
- Bump scala version to 3.3.4
  - wconf now works in scala 3.3.4, utilising msg instead of cat