### PR TITLE
PLATUI-3747: update banner to work with rebranded services

### DIFF
--- a/js/styles/_cookie-banner.scss
+++ b/js/styles/_cookie-banner.scss
@@ -15,7 +15,11 @@ $border-bottom-width: govuk-spacing(2);
   // when user changes colours in their browser.
   border-bottom: $border-bottom-width solid transparent;
 
-  background-color: $govuk-canvas-background-colour;
+  @include _govuk-rebrand(
+    "background-color",
+    $govuk-template-background-colour,
+    $_govuk-rebrand-template-background-colour
+  );
 }
 
 // Support older browsers which don't hide elements with the `hidden` attribute

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "core-js": "3.40.0",
         "css-loader": "7.1.2",
         "dot-properties": "1.1.0",
-        "govuk-frontend": "5.8.0",
+        "govuk-frontend": "5.10.1",
         "js-cookie": "^3.0.5",
         "playwright": "1.49.1",
         "style-loader": "4.0.0",
@@ -9185,9 +9185,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.8.0.tgz",
-      "integrity": "sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.1.tgz",
+      "integrity": "sha512-VmzKE+pkuOqEXhit0cGqic4i2mOQwflfXDiEcsa6Lrqs//rxV5AYf+C71jbREPwQLH4wYSJAlz/GlGoO5nik7Q==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "core-js": "3.40.0",
     "css-loader": "7.1.2",
     "dot-properties": "1.1.0",
-    "govuk-frontend": "5.8.0",
+    "govuk-frontend": "5.10.1",
     "js-cookie": "^3.0.5",
     "playwright": "1.49.1",
     "style-loader": "4.0.0",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object AppDependencies {
 
   private val bootstrapVersion = "9.11.0"
-  private val frontendVersion  = "12.0.0"
+  private val frontendVersion  = "12.2.0-SNAPSHOT"
   private val playVersion      = "play-30"
 
   val compile = Seq(


### PR DESCRIPTION
just a draft, easiest to wait for play-frontend-hmrc version that's compatible with rebrand to release - otherwise have to go through hoops to test it

still need to add some new VRT tests for this but just turned out to be really easy to enable