### PR TITLE
NOJIRA audit fixes

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -3,7 +3,5 @@
   "GHSA-3ppc-4f35-3m26": "minimatch ReDoS issue - repeated wildcards: devDependency only, no risk given our usage",
   "GHSA-23c5-xmqv-rm74": "minimatch ReDoS issue - nested *(): devDependency only, no risk given our usage",
   "GHSA-7r86-cg39-jmmj": "minimatch ReDoS issue - matchOne(): devDependency only, no risk given our usage",
-  "GHSA-vpq2-c234-7xj6": "@tootallnate/once: devDependency only, no risk given our usage",
-  "GHSA-r5fr-rjxr-66jc": "lodash vulnerable to Code Injection: devDependency only, no risk given our usage",
-  "GHSA-f23m-r3pf-42rh": "lodash vulnerable to Prototype Pollution via array path bypass: devDependency only, no risk given our usage"
+  "GHSA-vpq2-c234-7xj6": "@tootallnate/once: devDependency only, no risk given our usage"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4223,9 +4223,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -10105,9 +10105,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true
     },
     "node_modules/lodash.debounce": {


### PR DESCRIPTION
# Purpose of PR
- npm audit fix to address audit issues
- remove unfound vulnerabilities

> 2 of the excluded vulnerabilities did not match any of the found vulnerabilities: GHSA-r5fr-rjxr-66jc, GHSA-f23m-r3pf-42rh. They can be removed from the .nsprc file or --exclude -x flags.